### PR TITLE
Comment typo fix

### DIFF
--- a/unMain.pas
+++ b/unMain.pas
@@ -1577,7 +1577,7 @@ begin
           end;
         end;
       end;
-      { Create SSH tunnef if needed }
+      { Create SSH tunnel if needed }
       try
         if Method = 1 then
         begin


### PR DESCRIPTION
There is a typo in the comment for the section that creates an SSH tunnel. Here's a proposed fix.